### PR TITLE
Add transp property to event + improve date format

### DIFF
--- a/lib/twisted-caldav/client.rb
+++ b/lib/twisted-caldav/client.rb
@@ -129,6 +129,7 @@ module TwistedCaldav
         e.summary = event[:title]
         e.description = event[:description]
         e.ip_class = event[:ip_class] # PUBLIC, PRIVATE, CONFIDENTIAL
+        e.transp = event[:transp] # OPAQUE (busy, by default) or TRANSPARENT (free)
         e.location = event[:location]
         e.geo = event[:geo_location]
         e.status = event[:status]

--- a/lib/twisted-caldav/client.rb
+++ b/lib/twisted-caldav/client.rb
@@ -114,14 +114,9 @@ module TwistedCaldav
     def create_event(event)
       c = Icalendar::Calendar.new
 
-      date_method = event[:start].is_a?(Integer) ? 'at' : 'parse'
-
-      dtstart = Time.public_send(date_method, event[:start]).utc.strftime('%Y%m%dT%H%M%S')
-      dtend = Time.public_send(date_method, event[:end]).utc.strftime('%Y%m%dT%H%M%S')
-
       cal_event = c.event do |e|
-        e.dtstart = Icalendar::Values::DateOrDateTime.new(dtstart).call
-        e.dtend = Icalendar::Values::DateOrDateTime.new(dtend).call
+        e.dtstart = Icalendar::Values::DateOrDateTime.new(datetime_format(event[:start])).call
+        e.dtend = Icalendar::Values::DateOrDateTime.new(datetime_format(event[:end])).call
         e.categories = event[:categories] # Array
         e.contact = event[:contacts] # Array
         e.attendee = event[:attendees] # Array
@@ -221,6 +216,17 @@ module TwistedCaldav
       else
         true
       end
+    end
+
+    def datetime_format(value)
+      if value.is_a?(String)
+        datetime_format_ok = value.match?(/\d{8}T\d{6}/)
+        return value if datetime_format_ok
+      end
+
+      date = value.is_a?(Integer) ? Time.at(value) : Time.parse(value)
+
+      date.utc.strftime('%Y%m%dT%H%M%S')
     end
 
     def errorhandling(response)

--- a/spec/twisted-caldav_spec.rb
+++ b/spec/twisted-caldav_spec.rb
@@ -25,6 +25,18 @@ describe TwistedCaldav::Client do
     expect(@c.class.to_s).to eq('TwistedCaldav::Client')
   end
 
+  it 'check datetime_format with timezone' do
+    expect(@c.send(:datetime_format, '20130102T161119Z')).to eq('20130102T161119Z')
+  end
+
+  it 'check datetime_format without timezone' do
+    expect(@c.send(:datetime_format, '20130102T161119')).to eq('20130102T161119')
+  end
+
+  it 'check datetime_format with timestamp' do
+    expect(@c.send(:datetime_format, 1609462861)).to eq('20210101T010101')
+  end
+
   it 'create one event' do
     uid = UUID.new.generate
     uri_template = Addressable::Template.new 'http://localhost:5232/user/calendar/{uid}.ics'


### PR DESCRIPTION
- Add transp property to event : busy or free (opaque or transparent)
- Improve start and end format
 
start and end value :
- if `20130102T161119Z` with timezone, `20130102T161119` without TZ => the format is ok, nothing change
- if `2021-01-01 01:01` => `Time.parse()`
- if timestamp => `Time.at()`